### PR TITLE
Update Initialize-OSDBuilder.ps1

### DIFF
--- a/Public/Initialize-OSDBuilder.ps1
+++ b/Public/Initialize-OSDBuilder.ps1
@@ -28,7 +28,7 @@ function Initialize-OSDBuilder {
     }
 
     $global:GetOSDBuilderHome = $(Get-ItemProperty "HKCU:\Software\OSDeploy").GetOSDBuilderHome
-    if ($null -eq $global:GetOSDBuilderHome) {$global:GetOSDBuilderHome = "$env:SystemDrive\OSDBuilder"}
+    if (!$global:GetOSDBuilderHome) {$global:GetOSDBuilderHome = "$env:SystemDrive\OSDBuilder"}
     #===================================================================================================
     #   Initialize OSDBuilder Variables
     #===================================================================================================


### PR DESCRIPTION
Initialize-OSDBuilder doesn't work in my lab when using the default "C:\OSDBuilder" location
I do not pass the variable $SetHome and thus "HKCU:\Software\OSDeploy" registry key is not populated.
$global:GetOSDBuilderHome doesn't get set when using the $Null check against the registry value on line 31
If I make the change proposed, my issue resolves (Not tested on other labs yet, sorry)