### PR TITLE
added IncludeRecoveryPartition switch

### DIFF
--- a/Public/New-OSDBuilderVHD.ps1
+++ b/Public/New-OSDBuilderVHD.ps1
@@ -30,7 +30,8 @@ function New-OSDBuilderVHD {
         [Parameter(ValueFromPipelineByPropertyName)]
         [string]$FullName,
         [string]$OSDriveLabel = 'OSDisk',
-        [int32]$VHDSizeGB = 50
+        [int32]$VHDSizeGB = 50,
+        [switch]$Physical
     )
 
     Begin {
@@ -185,12 +186,12 @@ function New-OSDBuilderVHD {
             Add-PartitionAccessPath -DiskNumber $DiskNumber -PartitionNumber $PartitionOS.PartitionNumber -AssignDriveLetter
             $PartitionOS = Get-Partition -DiskNumber $DiskNumber -PartitionNumber $PartitionOS.PartitionNumber
             $PartitionOSVolume = [string]$PartitionOS.DriveLetter+":"
-
-            Write-Host '========================================================================================' -ForegroundColor DarkGray
-            Write-Host "Creating Recovery Partition 984MB NTFS" -ForegroundColor Green
-            $PartitionRecovery = New-Partition -DiskNumber $DiskNumber -GptType '{de94bba4-06d1-4d40-a16a-bfd50179d6ac}' -UseMaximumSize
-            $PartitionRecovery | Format-Volume -FileSystem NTFS -NewFileSystemLabel Recovery -Confirm:$false | Out-Null
-
+            If($Physical){
+                Write-Host '========================================================================================' -ForegroundColor DarkGray
+                Write-Host "Creating Recovery Partition 984MB NTFS" -ForegroundColor Green
+                $PartitionRecovery = New-Partition -DiskNumber $DiskNumber -GptType '{de94bba4-06d1-4d40-a16a-bfd50179d6ac}' -UseMaximumSize
+                $PartitionRecovery | Format-Volume -FileSystem NTFS -NewFileSystemLabel Recovery -Confirm:$false | Out-Null
+            }
             Write-Host '========================================================================================' -ForegroundColor DarkGray
             Write-Host "Expand-WindowsImage -ImagePath $VhdInstallWim -Index 1 -ApplyPath $PartitionOSVolume\" -ForegroundColor Green
             Try { Expand-WindowsImage -ImagePath $VhdInstallWim -Index 1 -ApplyPath $PartitionOSVolume\ -ErrorAction Stop | Out-Null }

--- a/Public/New-OSDBuilderVHD.ps1
+++ b/Public/New-OSDBuilderVHD.ps1
@@ -31,7 +31,7 @@ function New-OSDBuilderVHD {
         [string]$FullName,
         [string]$OSDriveLabel = 'OSDisk',
         [int32]$VHDSizeGB = 50,
-        [switch]$Physical
+        [switch]$IncludeRecoveryPartition
     )
 
     Begin {
@@ -186,7 +186,7 @@ function New-OSDBuilderVHD {
             Add-PartitionAccessPath -DiskNumber $DiskNumber -PartitionNumber $PartitionOS.PartitionNumber -AssignDriveLetter
             $PartitionOS = Get-Partition -DiskNumber $DiskNumber -PartitionNumber $PartitionOS.PartitionNumber
             $PartitionOSVolume = [string]$PartitionOS.DriveLetter+":"
-            If($Physical){
+            If($IncludeRecoveryPartition){
                 Write-Host '========================================================================================' -ForegroundColor DarkGray
                 Write-Host "Creating Recovery Partition 984MB NTFS" -ForegroundColor Green
                 $PartitionRecovery = New-Partition -DiskNumber $DiskNumber -GptType '{de94bba4-06d1-4d40-a16a-bfd50179d6ac}' -UseMaximumSize


### PR DESCRIPTION
To make the inclusion of the recovery partition optional when generating a VHD(X)