### PR TITLE
Adding a more granular inclusion and exclusion parameter for patches. 

### DIFF
--- a/Public/New-OSBuild.ps1
+++ b/Public/New-OSBuild.ps1
@@ -52,6 +52,10 @@ function New-OSBuild {
         )]
         [string[]]$Exclude = $global:SetOSDBuilder.NewOSBuildExclude,
 
+        #Excludeds specific KBs based on the KB number.
+        # -ExcludeKB '4577010','4577015'
+        [string[]]$ExcludeKB,
+
         #Executes Update-OSMedia
         #Without this parameter, Update-OSMedia is in Sandbox Mode where changes will not be made
         [Alias('Force')]
@@ -79,6 +83,10 @@ function New-OSBuild {
             'SSU'
         )]
         [string[]]$Include = $global:SetOSDBuilder.NewOSBuildInclude,
+
+        #Includes only specific KBs based on the KB number.
+        # -IncludeKB '4577010','4577015'
+        [string[]]$IncludeKB,
 
         #Pauses the function the Install.wim is dismounted
         #Useful for Testing
@@ -679,11 +687,17 @@ function New-OSBuild {
             #===================================================================================================
             #   Include Exclude
             #===================================================================================================
+            if ($IncludeKB) {
+                $OSDUpdates = $OSDUpdates | Where-Object {$_.KBNumber -in $IncludeKB}
+            }
             if ($Include) {
                 $OSDUpdates = $OSDUpdates | Where-Object {$_.UpdateGroup -in $Include}
             }
             if ($Exclude) {
                 $OSDUpdates = $OSDUpdates | Where-Object {$_.UpdateGroup -notin $Exclude}
+            }
+            if ($ExcludeKB){
+                $OSDUpdates = $OSDUpdates | Where-Object {$_.KBNumber -notin $ExcludeKB}
             }
             #===================================================================================================
             #   SelectUpdates


### PR DESCRIPTION
My end goal is to be able to programmatically pass in kb numbers for a build and to programmatically pass in KB numbers to exclude. This will let my organization schedule these updates and perpetually exclude KB numbers that we are tracking in our exclusion process but apply everything else. 