### PR TITLE
Added Conditional Download for OneDrive Setup

### DIFF
--- a/Public/New-OSBuild.ps1
+++ b/Public/New-OSBuild.ps1
@@ -1043,8 +1043,8 @@ function New-OSBuild {
                     }
 
                     # CREATE THE DIRECTORY PATHS FOR THE IMAGE AND OSDBUILDER CONTENT
-                    $OneDriveSetupImagePath = Join-Path -Path $SystemDirectory $OneDriveFileName
-                    $OneDriveSetupContentPath = Join-Path -Path $GetOSDBuilderPathContentOneDrive $OneDriveFileName
+                    $OneDriveSetupImagePath = Join-Path -Path $SystemDirectory -ChildPath $OneDriveFileName
+                    $OneDriveSetupContentPath = Join-Path -Path $GetOSDBuilderPathContentOneDrive -ChildPath $OneDriveFileName
 
                     # GET THE VERSION OF ONEDRIVE FROM THE IMAGE
                     $OneDriveSetupImageVersion = (Get-ItemProperty -Path $OneDriveSetupImagePath).VersionInfo.ProductVersion

--- a/Public/New-OSBuild.ps1
+++ b/Public/New-OSBuild.ps1
@@ -1061,7 +1061,8 @@ function New-OSBuild {
                             Write-Host -ForegroundColor Gray -Object ($indent + "Updating image with $OneDriveFileName version $OneDriveSetupVersion")
                             $null = robocopy "$GetOSDBuilderPathContentOneDrive" "$SystemDirectory" $OneDriveFileName /ndl /xx /b /np /ts /tee /r:0 /w:0 /Log+:"$Info\logs\$((Get-Date).ToString('yyyy-MM-dd-HHmmss'))-Update-OneDriveSetup.log"
                         } else {
-                            Write-Host -ForegroundColor Gray -Object ($indent + "Content directory has an older version or the same version of $OneDriveFileName as the image. No changes to $OneDriveFileName will be made to the image")
+                            Write-Host -ForegroundColor Gray -Object ($indent + "The version of $OneDriveFileName in the image is newer than the version in the OSDBuilder OneDrive content directory")
+                            Write-Host -ForegroundColor Gray -Object ($indent + "No changes to $OneDriveFileName will be made to the image")
                         }
                     }
 

--- a/Public/New-OSBuild.ps1
+++ b/Public/New-OSBuild.ps1
@@ -1048,20 +1048,20 @@ function New-OSBuild {
 
                     # GET THE VERSION OF ONEDRIVE FROM THE IMAGE
                     $OneDriveSetupImageVersion = (Get-ItemProperty -Path $OneDriveSetupImagePath).VersionInfo.ProductVersion
-                    Write-Host -ForegroundColor Gray -Object ($indent + "Existing Image $OneDriveFileName Version: $OneDriveSetupImageVersion")
+                    Write-Host -ForegroundColor Gray -Object ($indent + "Image $OneDriveFileName Version: $OneDriveSetupImageVersion")
 
                     # CHECK IF ONEDRIVE IS IN THE CONTENT DIRECTORY
                     if (Test-Path -Path $OneDriveSetupContentPath) {
                         # GET THE VERSION OF ONEDRIVE IN THE CONTENT DIRECTORY
                         $OneDriveSetupVersion = (Get-ItemProperty -Path $OneDriveSetupContentPath).VersionInfo.ProductVersion
-                        Write-Host -ForegroundColor Gray -Object ($indent + "Existing Content $OneDriveFileName Version: $OneDriveSetupVersion")
+                        Write-Host -ForegroundColor Gray -Object ($indent + "Content $OneDriveFileName Version: $OneDriveSetupVersion")
 
                         # COPY ONEDRIVE FROM THE CONTENT DIRECTORY TO THE IMAGE DIRECTORY ONLY IF THE IMAGE HAS AN OLDER VERSION
                         if ([Version]$OneDriveSetupImageVersion -lt [Version]$OneDriveSetupVersion) {
-                            Write-Host -ForegroundColor Gray -Object ($indent + "Updating image with $OneDriveFileName version $OneDriveSetupVersion")
+                            Write-Host -ForegroundColor Gray -Object ($indent + "Updating the image with $OneDriveFileName version $OneDriveSetupVersion")
                             $null = robocopy "$GetOSDBuilderPathContentOneDrive" "$SystemDirectory" $OneDriveFileName /ndl /xx /b /np /ts /tee /r:0 /w:0 /Log+:"$Info\logs\$((Get-Date).ToString('yyyy-MM-dd-HHmmss'))-Update-OneDriveSetup.log"
                         } else {
-                            Write-Host -ForegroundColor Gray -Object ($indent + "The version of $OneDriveFileName in the image is newer than the version in the OSDBuilder OneDrive content directory")
+                            Write-Host -ForegroundColor Gray -Object ($indent + "The version of $OneDriveFileName in the content directory is not newer than the image")
                             Write-Host -ForegroundColor Gray -Object ($indent + "No changes to $OneDriveFileName will be made to the image")
                         }
                     }

--- a/Public/New-OSBuild.ps1
+++ b/Public/New-OSBuild.ps1
@@ -1033,6 +1033,7 @@ function New-OSBuild {
                     Show-ActionTime
                     $OneDriveFileName = 'OneDriveSetup.exe'
                     Write-Host -ForegroundColor Green -Object "OS: Update $OneDriveFileName"
+                    $indent = '                  ' # 18 spaces
 
                     # SET THE SYSTEM DIRECTORY BASED ON THE ARCHITECTURE OF THE OS
                     if ($OSArchitecture -eq 'x86') {
@@ -1043,27 +1044,30 @@ function New-OSBuild {
 
                     # CREATE THE DIRECTORY PATHS FOR THE IMAGE AND OSDBUILDER CONTENT
                     $OneDriveSetupImagePath = Join-Path -Path $SystemDirectory $OneDriveFileName
-                    $OneDriveSetupPath = Join-Path -Path $GetOSDBuilderPathContentOneDrive $OneDriveFileName
+                    $OneDriveSetupContentPath = Join-Path -Path $GetOSDBuilderPathContentOneDrive $OneDriveFileName
 
                     # GET THE VERSION OF ONEDRIVE FROM THE IMAGE
                     $OneDriveSetupImageVersion = (Get-ItemProperty -Path $OneDriveSetupImagePath).VersionInfo.ProductVersion
-                    Write-Host -ForegroundColor Gray "                  Existing Image $OneDriveFileName Version $OneDriveSetupImageVersion"
+                    Write-Host -ForegroundColor Gray -Object ($indent + "Existing Image $OneDriveFileName Version: $OneDriveSetupImageVersion")
 
                     # CHECK IF ONEDRIVE IS IN THE CONTENT DIRECTORY
-                    if (Test-Path -Path $OneDriveSetupPath) {
+                    if (Test-Path -Path $OneDriveSetupContentPath) {
                         # GET THE VERSION OF ONEDRIVE IN THE CONTENT DIRECTORY
-                        $OneDriveSetupVersion = (Get-ItemProperty -Path $OneDriveSetupPath).VersionInfo.ProductVersion
+                        $OneDriveSetupVersion = (Get-ItemProperty -Path $OneDriveSetupContentPath).VersionInfo.ProductVersion
+                        Write-Host -ForegroundColor Gray -Object ($indent + "Existing Content $OneDriveFileName Version: $OneDriveSetupVersion")
 
                         # COPY ONEDRIVE FROM THE CONTENT DIRECTORY TO THE IMAGE DIRECTORY ONLY IF THE IMAGE HAS AN OLDER VERSION
                         if ([Version]$OneDriveSetupImageVersion -lt [Version]$OneDriveSetupVersion) {
-                            Write-Host -ForegroundColor Gray "                  Updating Image with $OneDriveFileName Version $OneDriveSetupVersion"
+                            Write-Host -ForegroundColor Gray -Object ($indent + "Updating image with $OneDriveFileName version $OneDriveSetupVersion")
                             $null = robocopy "$GetOSDBuilderPathContentOneDrive" "$SystemDirectory" $OneDriveFileName /ndl /xx /b /np /ts /tee /r:0 /w:0 /Log+:"$Info\logs\$((Get-Date).ToString('yyyy-MM-dd-HHmmss'))-Update-OneDriveSetup.log"
+                        } else {
+                            Write-Host -ForegroundColor Gray -Object ($indent + "Content directory has an older version of $OneDriveFileName than the image. No changes to $OneDriveFileName will be made to the image")
                         }
                     }
 
-                    Write-Host -ForegroundColor Cyan "                  To update $OneDriveFileName use one of the following commands:"
-                    Write-Host -ForegroundColor Cyan "                  Save-OSDBuilderDownload -ContentDownload 'OneDriveSetup Enterprise'"
-                    Write-Host -ForegroundColor Cyan "                  Save-OSDBuilderDownload -ContentDownload 'OneDriveSetup Production'"
+                    Write-Host -ForegroundColor Cyan -Object ($indent + "To update the OneDrive content directory, use one of the following commands:")
+                    Write-Host -ForegroundColor Cyan -Object ($indent + "Save-OSDBuilderDownload -ContentDownload 'OneDriveSetup Enterprise'")
+                    Write-Host -ForegroundColor Cyan -Object ($indent + "Save-OSDBuilderDownload -ContentDownload 'OneDriveSetup Production'")
                 }
                 #===================================================================================================
                 #	DismCleanupImage

--- a/Public/New-OSBuild.ps1
+++ b/Public/New-OSBuild.ps1
@@ -1061,11 +1061,11 @@ function New-OSBuild {
                             Write-Host -ForegroundColor Gray -Object ($indent + "Updating image with $OneDriveFileName version $OneDriveSetupVersion")
                             $null = robocopy "$GetOSDBuilderPathContentOneDrive" "$SystemDirectory" $OneDriveFileName /ndl /xx /b /np /ts /tee /r:0 /w:0 /Log+:"$Info\logs\$((Get-Date).ToString('yyyy-MM-dd-HHmmss'))-Update-OneDriveSetup.log"
                         } else {
-                            Write-Host -ForegroundColor Gray -Object ($indent + "Content directory has an older version of $OneDriveFileName than the image. No changes to $OneDriveFileName will be made to the image")
+                            Write-Host -ForegroundColor Gray -Object ($indent + "Content directory has an older version or the same version of $OneDriveFileName as the image. No changes to $OneDriveFileName will be made to the image")
                         }
                     }
 
-                    Write-Host -ForegroundColor Cyan -Object ($indent + "To update the OneDrive content directory, use one of the following commands:")
+                    Write-Host -ForegroundColor Cyan -Object ($indent + 'To update the OneDrive content directory, use one of the following commands:')
                     Write-Host -ForegroundColor Cyan -Object ($indent + "Save-OSDBuilderDownload -ContentDownload 'OneDriveSetup Enterprise'")
                     Write-Host -ForegroundColor Cyan -Object ($indent + "Save-OSDBuilderDownload -ContentDownload 'OneDriveSetup Production'")
                 }

--- a/Public/Save-OSDBuilderDownload.ps1
+++ b/Public/Save-OSDBuilderDownload.ps1
@@ -270,7 +270,7 @@ function Save-OSDBuilderDownload {
             
                 # CHECK IF THE ONEDRIVESETUP.EXE FILE ALREADY EXISTS
                 if ((Test-Path -Path "$filePath") -eq $false) {
-                    Write-Verbose -Message "$Name not found at $Path..." -Verbose
+                    Write-Verbose -Message "$Name not found at $Path" -Verbose
                     $exeExists = $false
                 } else {
                     $exeExists = $true
@@ -299,9 +299,9 @@ function Save-OSDBuilderDownload {
                         Write-Warning -Message 'Content could not be downloaded'
                     }
                 } else {
+                    Write-Verbose -Message "$Name does not need to be updated. Skipping download" -Verbose
                     Write-Verbose -Message "OneDriveSetup.exe Version: $exeVersion" -Verbose
                     Write-Verbose -Message "Latest Version: $latestVersion" -Verbose
-                    Write-Verbose -Message "$Name does not need to be updated. Skipping download" -Verbose
                 }
             }
             #===================================================================================================

--- a/Public/Save-OSDBuilderDownload.ps1
+++ b/Public/Save-OSDBuilderDownload.ps1
@@ -277,10 +277,10 @@ function Save-OSDBuilderDownload {
                     $exeOutdated = $false
             
                     # GET THE VERSION NUMBER OF ONEDRIVESETUP.EXE
-                    $exeVersion = (Get-ItemProperty -Path "$filePath" -Name VersionInfo | Select-Object -ExpandProperty VersionInfo).ProductVersion
+                    $exeVersion = (Get-ItemProperty -Path "$filePath").VersionInfo.ProductVersion
             
                     # COMPARE THE VERSION OF ONEDRIVESETUP.EXE WITH WHAT'S LISTED ONLINE
-                    if ($exeVersion -lt $latestVersion) {
+                    if ([Version]$exeVersion -lt [Version]$latestVersion) {
                         Write-Verbose -Message "$Name $exeVersion is out of date. The latest version is $latestVersion..." -Verbose
                         $exeOutdated = $true
                     }


### PR DESCRIPTION
## Problem

When using `Save-OSDBuilderDownload`, OneDriveSetup.exe is always downloaded even if the `$GetOSDBuilderPathContentOneDrive` directory already has the latest version downloaded (or newer if using the Insider release).

When using `New-OSBuild`, OneDriveSetup.exe is always copied to the image if it exists in the `$GetOSDBuilderPathContentOneDrive` directory even if it's an older version than what's already in the image.

Both of these problems introduce unnecessary time and bandwidth usage during the build or content preparation process, and they can lead to scenarios where OneDrive is actually downgraded to an older version.

## Solution

To resolve these problems, I created a function in `Save-OSDBuilderDownload` that only downloads OneDriveSetup.exe if needed and added similar logic to `New-OSBuild`.

## Save-OSDBuilderDownload Change Summary

### Scenario 1

**Scenario**: OneDriveSetup.exe is already downloaded and is the most recent version or newer

**Result**: OneDriveSetup.exe will _not_ be downloaded

### Scenario 2

**Scenario**: OneDriveSetup.exe is not downloaded or cannot be found

**Result**: OneDriveSetup.exe will be downloaded

### Scenario 3

**Scenario**: OneDriveSetup.exe is already downloaded, but is not the most recent version

**Result**: OneDriveSetup.exe will be downloaded

### Output

Output for these scenarios will look like this:

![PowerShell Prompt](https://user-images.githubusercontent.com/5446414/122562232-d7974000-d010-11eb-9b7b-9c88547170eb.png)

## New-OSBuild Change Summary

### Scenario 1

**Scenario**: OneDriveSetup.exe in the content directory is not newer than what's in the image's System directory

**Result**: OneDriveSetup.exe will _not_ be copied from the content directory to the image's system directory

### Output

Output for this scenario will look like this:

![PowerShell Prompt](https://user-images.githubusercontent.com/5446414/122584196-0ff64880-d028-11eb-91bc-c0c2eb7e221b.png)
