### PR TITLE
deploy PE drivers to all the WIM files

### DIFF
--- a/Private/AllFunctions.ps1
+++ b/Private/AllFunctions.ps1
@@ -246,8 +246,8 @@ function Add-ContentDriversPE {
     #=================================================
     $MountPaths = @(
         $MountWinPE
-        $MountWinPE
-        $MountWinPE
+        $MountWinRE
+        $MountWinSE
     )
     #=================================================
     #   Task


### PR DESCRIPTION
Looking at the git history I assume that this change is correct, it certainly
used to deploy drivers to all the WIMs, and I am now no longer able to install
my ISO image straight to a VM, inspecting `boot.wim` revealed only index 1 (WinPE) had
the drivers included, not index 2 (Win Setup).