### PR TITLE
Update Save-OSDBuilderDownload.ps1

### DIFF
--- a/Public/Save-OSDBuilderDownload.ps1
+++ b/Public/Save-OSDBuilderDownload.ps1
@@ -277,7 +277,7 @@ function Save-OSDBuilderDownload {
             #   Download File
             #=================================================
             if ($UseWebClient -eq $true) {
-                $WebClientObj.DownloadFile("$($Item.OriginUri)","$DownloadFullPath")
+                $WebClientObj.DownloadFile("$DownloadUrl","$DownloadPath\$DownloadFile")
             }
             elseif ($UseWebRequest -eq $true) {
                 Invoke-WebRequest -Uri $DownloadUrl -OutFile "$DownloadPath\$DownloadFile"


### PR DESCRIPTION
OSDBuilder -Download OneDriveEnterprise fails with error: Exception calling "DownloadFile" with "2" argument(s): "The path is not of a legal form."