### PR TITLE
Workaround for RPC/DISM error servicing Win11 22H2

### DIFF
--- a/Private/AllFunctions.ps1
+++ b/Private/AllFunctions.ps1
@@ -6565,9 +6565,15 @@ function Update-CumulativeOS {
         Write-Host -ForegroundColor Cyan "INSTALLING        " -NoNewline
         Write-Host -ForegroundColor Gray "$($Update.Title) - $(Split-Path $Update.OriginUri -Leaf)"
 
+        # Workaround for RPC/DISM error on Win11 22H2
         $TestWindowsPackageCAB = $null
-        $TestWindowsPackageCAB = Test-WindowsPackageCAB -Path $MountDirectory -PackagePath $UpdateLCU
-
+        if ($OSImageName -like '*Windows 11*' -and $ReleaseID -eq '22H2') {
+            $TestWindowsPackageCAB = 'CombinedMSU'
+        }
+        else {
+            $TestWindowsPackageCAB = Test-WindowsPackageCAB -Path $MountDirectory -PackagePath $UpdateLCU
+        }
+	
         #=================================================
         #   CombinedMSU
         #   This is for Windows 11 need to run as an MSU


### PR DESCRIPTION
Update Update-CumulativeOS in AllFunctions.ps1
Error is caused by the function Test-WindowsPackageCAB used in the Update-CumulativeOS function. For some reason Get-WindowsPackage -PackagePath errors out on (only) W11 22H2.
After the RPC error all subsequent DISM calls seem to fail. No idea why this happens on Win11 22H2 only. Updating Update-CumulativeOS to skip the Test-WindowsPackageCAB and setting it "manually" to CombinedMSU if OS is Win11 22H2 is a workaround.
Subsequent Update-OSMedia and New-OSDBuild completes successfully after this change.