### PR TITLE
Handling for install.wim greater than 4GB

### DIFF
--- a/Public/New-OSDBuilderUSB.ps1
+++ b/Public/New-OSDBuilderUSB.ps1
@@ -91,6 +91,7 @@ function New-OSDBuilderUSB {
         Write-Warning "Install.wim larger than 4GB will FAIL"
 
         # TODO: Create a check if install.wim is greater than 4GB or the "split" parameter is selected, then split the wim file into multiple .swm files of the desired size (4GB exactly, if not using the split and splitsize parameters).
+        # Example: Dism /Split-Image /ImageFile:C:\install.wim /SWMFile:C:\images\split\install.swm /FileSize:4000
 
         #=================================================
         Write-Verbose '19.1.14 Select Source OSMedia'

--- a/Public/New-OSDBuilderUSB.ps1
+++ b/Public/New-OSDBuilderUSB.ps1
@@ -88,7 +88,7 @@ function New-OSDBuilderUSB {
         Write-Host -ForegroundColor Green "$($MyInvocation.MyCommand.Name) PROCESS"
 
         Write-Warning "USB will be formatted FAT32"
-        Write-Warning "Install.wim larger than 4GB will FAIL"
+        Write-Warning "Install.wim larger than 4GB will be split into swm files, if the Split parameter is not already specified"
 
         #=================================================
         Write-Verbose '19.1.14 Select Source OSMedia'

--- a/Public/New-OSDBuilderUSB.ps1
+++ b/Public/New-OSDBuilderUSB.ps1
@@ -132,6 +132,7 @@ function New-OSDBuilderUSB {
             #Copy Files from ISO to USB and split the install.wim if needed or if specified by the split parameter
             if ($Split -eq $true -or $WIMSize -gt 4000){
                 #Create .swm files from the install.wim and copy them over instead of the install.wim (keeps filesize down for FAT32)
+                New-Item -Path "$($Results.DriveLetter):\" -Name "Sources" -ItemType Directory -Force -Verbose
                 Dism /Split-Image /ImageFile:"$($SelectedOSMedia.FullName)\OS\Sources\install.wim" /SWMFile:"$($Results.DriveLetter):\Sources\install.swm" /FileSize:$SplitSize /Verbose
                 Copy-Item -Path "$($SelectedOSMedia.FullName)\OS\*" -Destination "$($Results.DriveLetter):" -Recurse -Exclude "$($SelectedOSMedia.FullName)\OS\Sources\install.wim" -Verbose
             } else {

--- a/Public/New-OSDBuilderUSB.ps1
+++ b/Public/New-OSDBuilderUSB.ps1
@@ -13,6 +13,13 @@ Full Path of the OSDBuilder Media
 
 .PARAMETER USBLabel
 Label for the USB Drive
+
+.PARAMETER Split
+Split install.wim into multiple .swm files. This will be automatically set to $true if the file is reported to be over 4GB.
+
+.PARAMETER SplitSize
+The desired size of the .swm files created when using the "Split" parameter. Note: The integer value should be in MB (ie. 4000 is 4GB)
+
 #>
 function New-OSDBuilderUSB {
     [CmdletBinding()]
@@ -21,8 +28,33 @@ function New-OSDBuilderUSB {
         [string]$FullName,
         
         [ValidateLength(1,11)]
-        [string]$USBLabel
+        [string]$USBLabel,
+
+        [Parameter]
+        [Switch]$Split
     )
+
+    dynamicparam
+    {
+      if ($Split -eq $true)
+      {
+        $parameterAttribute = [System.Management.Automation.ParameterAttribute]@{
+            ParameterSetName = "__AllParameterSets"
+            Mandatory = $true
+        }
+  
+        $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+        $attributeCollection.Add($parameterAttribute)
+  
+        $dynParam1 = [System.Management.Automation.RuntimeDefinedParameter]::new(
+          'SplitSize', [Int32], $attributeCollection
+        )
+  
+        $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+        $paramDictionary.Add('SplitSize', $dynParam1)
+        return $paramDictionary
+      }
+    }
 
     Begin {
         #=================================================
@@ -47,6 +79,8 @@ function New-OSDBuilderUSB {
 
         $AllMyOSDBMedia = @()
         $AllMyOSDBMedia = [array]$AllMyOSMedia + [array]$AllMyOSBuilds + [array]$AllMyPEBuilds
+
+        # TODO: Create variable with size of the install.wim
     }
 
     Process {
@@ -55,6 +89,8 @@ function New-OSDBuilderUSB {
 
         Write-Warning "USB will be formatted FAT32"
         Write-Warning "Install.wim larger than 4GB will FAIL"
+
+        # TODO: Create a check if install.wim is greater than 4GB or the "split" parameter is selected, then split the wim file into multiple .swm files of the desired size (4GB exactly, if not using the split and splitsize parameters).
 
         #=================================================
         Write-Verbose '19.1.14 Select Source OSMedia'

--- a/Public/New-OSDBuilderUSB.ps1
+++ b/Public/New-OSDBuilderUSB.ps1
@@ -132,7 +132,7 @@ function New-OSDBuilderUSB {
             #Copy Files from ISO to USB and split the install.wim if needed or if specified by the split parameter
             if ($Split -eq $true -or $WIMSize -gt 4000){
                 #Create .swm files from the install.wim and copy them over instead of the install.wim (keeps filesize down for FAT32)
-                Dism /Split-Image /ImageFile:"$($SelectedOSMedia.FullName)\OS\Sources\install.wim" /SWMFile:"$($SelectedOSMedia.FullName)\OS\Sources\install.swm" /FileSize:$SplitSize /Verbose
+                Dism /Split-Image /ImageFile:"$($SelectedOSMedia.FullName)\OS\Sources\install.wim" /SWMFile:"$($Results.DriveLetter):\Sources\install.swm" /FileSize:$SplitSize /Verbose
                 Copy-Item -Path "$($SelectedOSMedia.FullName)\OS\*" -Destination "$($Results.DriveLetter):" -Recurse -Exclude "$($SelectedOSMedia.FullName)\OS\Sources\install.wim" -Verbose
             } else {
                 Copy-Item -Path "$($SelectedOSMedia.FullName)\OS\*" -Destination "$($Results.DriveLetter):" -Recurse -Verbose


### PR DESCRIPTION
Added a Split parameter and a SplitSize dynamic parameter to handle when/if an install.wim is larger than 4GB, or if you wish to split the install.wim in general.

The install.wim will be split into install.swm, install1.swm, etc. This is so that the USB build process can continue unaffected by the size of the wim file.