### PR TITLE
24H2 Additional Support

### DIFF
--- a/Public/Get-OSImport.ps1
+++ b/Public/Get-OSImport.ps1
@@ -30,7 +30,7 @@ function Get-OSMedia {
         [string]$OSMajorVersion,
 
         #Filter the OSMedia by OS Release Id
-        [ValidateSet ('22H2','21H2','21H1','20H2',2004,1909,1903,1809)]
+        [ValidateSet ('24H2','23H2','22H2','21H2','21H1','20H2',2004,1909,1903,1809)]
         [string]$OSReleaseId,
         
         #Filter the OSMedia by Image Revision
@@ -178,7 +178,10 @@ function Get-OSMedia {
             if ($RegValueCurrentBuild -eq 19043) {$ReleaseId = '21H1'}
             if ($RegValueCurrentBuild -eq 19044) {$ReleaseId = '21H2'} #Windows
             if ($RegValueCurrentBuild -eq 22000) {$ReleaseId = '21H2'} #Windows 11
-            if ($RegValueCurrentBuild -eq 20348) {$ReleaseId = '21H2'} #Server 2022  
+            if ($RegValueCurrentBuild -eq 20348) {$ReleaseId = '21H2'} #Server 2022
+            if ($RegValueCurrentBuild -eq 22621) {$ReleaseId = '22H2'} #Windows 11 22H2
+            if ($RegValueCurrentBuild -eq 22631) {$ReleaseId = '23H2'} #Windows 11 23H2
+            if ($RegValueCurrentBuild -eq 26100) {$ReleaseId = '24H2'} #Server 2025 and Windows 11 24H2  
 
             Write-Verbose "ReleaseId: $ReleaseId"
             Write-Verbose "CurrentBuild: $RegValueCurrentBuild"

--- a/Public/Get-OSMedia.ps1
+++ b/Public/Get-OSMedia.ps1
@@ -30,7 +30,7 @@ function Get-OSMedia {
         [string]$OSMajorVersion,
 
         #Filter the OSMedia by OS Release Id
-        [ValidateSet ('22H2','21H2','21H1','20H2',2004,1909,1903,1809,1803,1709,1703,1607,1511,1507)]
+        [ValidateSet ('24H2','23H2','22H2','21H2','21H1','20H2',2004,1909,1903,1809,1803,1709,1703,1607,1511,1507)]
         [string]$OSReleaseId,
         
         #Filter the OSMedia by Image Revision
@@ -193,6 +193,9 @@ function Get-OSMedia {
             if ($RegValueCurrentBuild -eq 19044) {$ReleaseId = '21H2'} #Windows
             if ($RegValueCurrentBuild -eq 22000) {$ReleaseId = '21H2'} #Windows 11
             if ($RegValueCurrentBuild -eq 20348) {$ReleaseId = '21H2'} #Server 2022
+            if ($RegValueCurrentBuild -eq 22621) {$ReleaseId = '22H2'} #Windows 11 22H2
+            if ($RegValueCurrentBuild -eq 22631) {$ReleaseId = '23H2'} #Windows 11 23H2
+            if ($RegValueCurrentBuild -eq 26100) {$ReleaseId = '24H2'} #Server 2025 and Windows 11 24H2
 
             Write-Verbose "ReleaseId: $ReleaseId"
             Write-Verbose "CurrentBuild: $RegValueCurrentBuild"

--- a/Public/Import-OSMedia.ps1
+++ b/Public/Import-OSMedia.ps1
@@ -108,6 +108,10 @@ function Import-OSMedia {
         #Windows Server 2022 Standard (Desktop Experience)
         #Windows Server 2022 Datacenter
         #Windows Server 2022 Datacenter (Desktop Experience)
+        #Windows Server 2025 Standard
+        #Windows Server 2025 Standard (Desktop Experience)
+        #Windows Server 2025 Datacenter
+        #Windows Server 2025 Datacenter (Desktop Experience)
         [ValidateSet(`
             'Windows 10 Education',`
             'Windows 10 Enterprise',`
@@ -150,7 +154,11 @@ function Import-OSMedia {
             'Windows Server 2022 Standard',`
             'Windows Server 2022 Standard (Desktop Experience)',`
             'Windows Server 2022 Datacenter',`
-            'Windows Server 2022 Datacenter (Desktop Experience)'
+            'Windows Server 2022 Datacenter (Desktop Experience)',`
+            'Windows Server 2025 Standard',`
+            'Windows Server 2025 Standard (Desktop Experience)',`
+            'Windows Server 2025 Datacenter',`
+            'Windows Server 2025 Datacenter (Desktop Experience)'
         )]
         [string[]]$ImageName = $global:SetOSDBuilder.ImportOSMediaImageName,
 

--- a/Public/New-OSBuildTask.ps1
+++ b/Public/New-OSBuildTask.ps1
@@ -244,6 +244,8 @@ function New-OSBuildTask {
             if ($TaskName -match '21H1') {$OSMedia = $OSMedia | Where-Object {$_.ReleaseId -eq '21H1'}}
             if ($TaskName -match '21H2') {$OSMedia = $OSMedia | Where-Object {$_.ReleaseId -eq '21H2'}}
             if ($TaskName -match '22H2') {$OSMedia = $OSMedia | Where-Object {$_.ReleaseId -eq '22H2'}}
+            if ($TaskName -match '23H2') {$OSMedia = $OSMedia | Where-Object {$_.ReleaseId -eq '23H2'}}
+            if ($TaskName -match '24H2') {$OSMedia = $OSMedia | Where-Object {$_.ReleaseId -eq '24H2'}}
     
             Try {
                 $OSMedia = $OSMedia | Out-GridView -OutputMode Single -Title 'Select a Source OSMedia to use for this Task (Cancel to Exit)'


### PR DESCRIPTION
24H2  ReleaseID support added Get-OSImport, Get-OSMedia, Import-OSMedia, and New-OSBuildTask.  

This enables filtering based on the ReleaseID parameter for newer Windows 11 and Windows Server versions in the Get-OSImport, Get-OSMedia, Import-OSMedia, and New-OSBuildTask commands.

Tested on Windows Server 2022 with PowerShell 7 against Windows 11 23H2 and Windows Server 2025 OS Media.